### PR TITLE
change where the pdf is sampled when visualizing

### DIFF
--- a/mlpf/data/analysis/configs/visualization/default.yaml
+++ b/mlpf/data/analysis/configs/visualization/default.yaml
@@ -1,4 +1,3 @@
-bandwidth_coeff: 0.03
+bandwidth_coeff: 0.01
 bins: 100
 kernel: cosine
-relative_gap_tolerance: 0.03

--- a/mlpf/data/analysis/visualization/grid_pdf_estimates.py
+++ b/mlpf/data/analysis/visualization/grid_pdf_estimates.py
@@ -23,8 +23,7 @@ def visualize_grid_pdfs(ppc_list: List[Dict],
                         columns: List[Union[BusTableIds, GeneratorTableIds, BranchTableIds, GeneratorCostTableIds]] = None,
                         kernel: str = "tophat",
                         bandwidth_coeff: float = 0.05,
-                        axes=None,
-                        relative_gap_tolerance: float = 0.03):
+                        axes=None):
     """
     Estimate and plot the probability density function of each specified column for the specified bus type and table in the ppc list. If no axes list is provided
     new figures will be created.
@@ -39,14 +38,13 @@ def visualize_grid_pdfs(ppc_list: List[Dict],
     will overfit to the given samples. To large of a value will not capture enough detail.
     :param axes: A numpy array of Matplotlib.PyPlot.Axes objects onto which to plot the estimates. If None,
     new figures will be created for every column.
-    :param relative_gap_tolerance: How large(relatively compared to the entire width) can the gaps in the pdf be before the line crossing them is cut.
     :return:
     """
 
     dataset = ppc_list_extract_bus_type(ppc_list, table, bus_type)
     data_frame = generate_data_frame(dataset, table, columns)
 
-    visualize_pdf_data_frame(data_frame, kernel, bandwidth_coeff, axes, relative_gap_tolerance=relative_gap_tolerance)
+    visualize_pdf_data_frame(data_frame, kernel, bandwidth_coeff, axes)
 
 
 def visualize_grid_histograms(ppc_list: List[Dict],
@@ -86,14 +84,7 @@ def main(cfg):
     fig, axes = create_subplots_grid(num_columns)
 
     fig.tight_layout()
-    visualize_grid_pdfs(ppc_list,
-                        table,
-                        bus_type=bus_type,
-                        columns=columns,
-                        kernel=cfg.visualization.kernel,
-                        bandwidth_coeff=cfg.visualization.bandwidth_coeff,
-                        axes=axes,
-                        relative_gap_tolerance=cfg.visualization.relative_gap_tolerance)
+    visualize_grid_pdfs(ppc_list, table, bus_type=bus_type, columns=columns, kernel=cfg.visualization.kernel, bandwidth_coeff=cfg.visualization.bandwidth_coeff, axes=axes)
 
     for ax in axes.flatten():
         ax.set_ylim(bottom=0)

--- a/mlpf/data/analysis/visualization/node_pdf_estimates.py
+++ b/mlpf/data/analysis/visualization/node_pdf_estimates.py
@@ -20,9 +20,9 @@ def visualize_node_pdfs(ppc_list: List[Dict],
                         table: PPCTables,
                         node_numbers: List[int],
                         columns: List[Union[BusTableIds, GeneratorTableIds, BranchTableIds, GeneratorCostTableIds]] = None,
-                        kernel: str = "tophat", bandwidth_coeff: float = 0.05,
-                        axes: ndarray[Axes] = None,
-                        relative_gap_tolerance: float = 0.03):
+                        kernel: str = "tophat",
+                        bandwidth_coeff: float = 0.05,
+                        axes: ndarray[Axes] = None):
     """
     Estimate and plot the probability density function of each specified column for the specified node and table in the ppc list. If no axes list is provided
     new figures will be created.
@@ -37,14 +37,13 @@ def visualize_node_pdfs(ppc_list: List[Dict],
     will overfit to the given samples. To large of a value will not capture enough detail.
     :param axes: A numpy array of Matplotlib.PyPlot.Axes objects onto which to plot the estimates. If None,
     new figures will be created for every column.
-    :param relative_gap_tolerance: How large(relatively compared to the entire width) can the gaps in the pdf be before the line crossing them is cut.
     :return:
     """
 
     dataset = ppc_list_extract_nodes(ppc_list, table, node_numbers=node_numbers)
     data_frame = generate_data_frame(dataset, table, columns)
 
-    visualize_pdf_data_frame(data_frame, kernel, bandwidth_coeff, axes, relative_gap_tolerance=relative_gap_tolerance)
+    visualize_pdf_data_frame(data_frame, kernel, bandwidth_coeff, axes)
 
 
 def visualize_node_histograms(ppc_list: List[Dict],
@@ -82,14 +81,8 @@ def main(cfg):
     fig, axes = create_subplots_grid(num_columns)
 
     fig.tight_layout()
-    visualize_node_pdfs(ppc_list,
-                        table,
-                        node_numbers=cfg.node_numbers,
-                        columns=columns,
-                        kernel=cfg.visualization.kernel,
-                        bandwidth_coeff=cfg.visualization.bandwidth_coeff,
-                        axes=axes,
-                        relative_gap_tolerance=cfg.visualization.relative_gap_tolerance)
+    visualize_node_pdfs(ppc_list, table, node_numbers=cfg.node_numbers, columns=columns, kernel=cfg.visualization.kernel, bandwidth_coeff=cfg.visualization.bandwidth_coeff,
+                        axes=axes)
 
     for ax in axes.flatten():
         ax.set_ylim(bottom=0)

--- a/mlpf/data/analysis/visualization/visualize.py
+++ b/mlpf/data/analysis/visualization/visualize.py
@@ -8,12 +8,7 @@ from sklearn.neighbors import KernelDensity
 from matplotlib import pyplot as plt
 
 
-def visualize_pdf_data_frame(data_frame: DataFrame,
-                             kernel: str = "tophat",
-                             bandwidth_coeff: float = 0.05,
-                             axes: ndarray[Axes] = None,
-                             max_samples: int = 2500,
-                             relative_gap_tolerance: float = 0.03):
+def visualize_pdf_data_frame(data_frame: DataFrame, kernel: str = "tophat", bandwidth_coeff: float = 0.05, axes: ndarray[Axes] = None, max_samples: int = 2500):
     """
     Estimate and plot the probability density function of each column of the given dataframe. If no axes list is provided
     new figures will be created.
@@ -28,7 +23,6 @@ def visualize_pdf_data_frame(data_frame: DataFrame,
     :param max_samples: Since estimating the pdf could take a lot of time for a large number of samples, _max_samples_ provides a
     limit on the number of samples to take into consideration. If the number of samples is larger than _max_samples_ then approximately
     _max_samples_ samples are randomly sampled.
-    :param relative_gap_tolerance: How large(relatively compared to the entire width) can the gaps in the pdf be before the line crossing them is cut.
     :return:
     """
     for i, column in enumerate(data_frame):
@@ -40,7 +34,7 @@ def visualize_pdf_data_frame(data_frame: DataFrame,
 
         x_values = data_frame[column]
 
-        plot_pdf(x_values, ax, max_samples, kernel, bandwidth_coeff, relative_gap_tolerance)
+        plot_pdf(x_values, ax, max_samples, kernel, bandwidth_coeff)
 
         ax.set_title(column)
         ax.set_xlabel(column)
@@ -73,12 +67,7 @@ def visualize_histogram_data_frame(data_frame: DataFrame,
         ax.set_xlabel(column)
 
 
-def plot_pdf(x_values: ndarray,
-             ax: Axes,
-             max_samples: int = 2500,
-             kernel: str = "tophat",
-             bandwidth_coeff: float = 0.05,
-             relative_gap_tolerance: float = 0.03):
+def plot_pdf(x_values: ndarray, ax: Axes, max_samples: int = 2500, kernel: str = "tophat", bandwidth_coeff: float = 0.05):
     """
     Estimate and plot the probability density function of the given array.
 
@@ -91,7 +80,6 @@ def plot_pdf(x_values: ndarray,
     :param max_samples: Since estimating the pdf could take a lot of time for a large number of samples, _max_samples_ provides a
     limit on the number of samples to take into consideration. If the number of samples is larger than _max_samples_ then approximately
     _max_samples_ samples are randomly sampled.
-    :param relative_gap_tolerance: How large(relatively compared to the entire width) can the gaps in the pdf be before the line crossing them is cut
     :return:
     """
 
@@ -101,20 +89,14 @@ def plot_pdf(x_values: ndarray,
 
     x_values = x_values.sort_values().to_numpy().reshape(-1, 1)
 
-    total_width = np.max(x_values) - np.min(x_values)
-
-    # find large gaps in the pdf
-    differences = np.diff(x_values, axis=0, append=0)
-    large_difference_mask = (differences > total_width * relative_gap_tolerance).flatten()
-
     if len(np.unique(x_values)) > 100:
+        total_width = np.max(x_values) - np.min(x_values)
         kde = KernelDensity(kernel=kernel, bandwidth=bandwidth_coeff * total_width).fit(x_values)
-        pdf_estimate = np.exp(kde.score_samples(x_values))
 
-        # where there are large gaps in the pdf insert a NaN so as not to connect lines across a large gap
-        pdf_estimate[large_difference_mask] = np.nan
+        x_linspace = np.linspace(start=np.min(x_values), stop=np.max(x_values), num=max_samples).reshape(-1, 1)
+        pdf_estimate = np.exp(kde.score_samples(x_linspace))
 
-        ax.fill_between(x_values.flatten(), pdf_estimate, alpha=0.5)
+        ax.fill_between(x_linspace.flatten(), pdf_estimate, alpha=0.5)
 
     else:
         # when there aren't a lot of unique values it makes sense to just do a histogram/bar plot


### PR DESCRIPTION
change where the pdf is sampled when visualizing - simple with linspace; this removed the need for relative gap tolerance